### PR TITLE
Improve block render cb

### DIFF
--- a/php/Block.php
+++ b/php/Block.php
@@ -63,7 +63,7 @@ class Block {
 	 * @return string The markup of the block.
 	 */
 	public function render_callback( $attributes, $content, $block ) {
-		$post_types = get_post_types( array( 'public' => true ) );
+		$post_types = get_post_types( [ 'public' => true ] );
 		$class_name = $attributes['className'];
 		ob_start();
 
@@ -76,10 +76,10 @@ class Block {
 				$post_type_object = get_post_type_object( $post_type_slug );
 				$post_count       = count(
 					get_posts(
-						array(
+						[
 							'post_type'      => $post_type_slug,
 							'posts_per_page' => -1,
-						)
+						]
 					)
 				);
 
@@ -92,23 +92,23 @@ class Block {
 
 			<?php
 			$query = new WP_Query(
-				array(
-					'post_type'     => array( 'post', 'page' ),
+				[
+					'post_type'     => [ 'post', 'page' ],
 					'post_status'   => 'any',
-					'date_query'    => array(
-						array(
+					'date_query'    => [
+						[
 							'hour'    => 9,
 							'compare' => '>=',
-						),
-						array(
+						],
+						[
 							'hour'    => 17,
 							'compare' => '<=',
-						),
-					),
+						],
+					],
 					'tag'           => 'foo',
 					'category_name' => 'baz',
-					'post__not_in'  => array( get_the_ID() ),
-				)
+					'post__not_in'  => [ get_the_ID() ],
+				]
 			);
 
 			if ( $query->found_posts ) :

--- a/php/Block.php
+++ b/php/Block.php
@@ -107,7 +107,8 @@ class Block {
 			</p>
 
 			<?php
-			$query = new WP_Query(
+			$current_post = get_the_ID();
+			$query        = new WP_Query(
 				[
 					'post_type'     => [ 'post', 'page' ],
 					'post_status'   => 'any',
@@ -123,7 +124,6 @@ class Block {
 					],
 					'tag'           => 'foo',
 					'category_name' => 'baz',
-					'post__not_in'  => [ get_the_ID() ],
 				]
 			);
 
@@ -135,8 +135,10 @@ class Block {
 
 				foreach ( array_slice( $query->posts, 0, 5 ) as $post ) :
 					?>
-					<li><?php echo esc_html( $post->post_title ); ?></li>
+					<?php if ( $post->ID !== $current_post ) : ?>
+						<li><?php echo esc_html( $post->post_title ); ?></li>
 								<?php
+					endif;
 				endforeach;
 			endif;
 			?>

--- a/php/Block.php
+++ b/php/Block.php
@@ -66,8 +66,8 @@ class Block {
 		$post_types = get_post_types( [ 'public' => true ] );
 		$class_name = $attributes['className'];
 		ob_start();
-
 		?>
+
 		<div class="<?php echo esc_attr( $class_name ); ?>">
 			<h2><?php esc_html_e( 'Post Counts', 'site-counts' ); ?></h2>
 			<ul>
@@ -82,17 +82,16 @@ class Block {
 						]
 					)
 				);
-
 				?>
 				<li>
-				<?php
-				echo sprintf(
-					'%1$s %2$d %3$s',
-					esc_html__( 'There are', 'site-counts' ),
-					absint( $post_count ),
-					esc_html( $post_type_object->labels->name )
-				);
-				?>
+					<?php
+					echo sprintf(
+						'%1$s %2$d %3$s',
+						esc_html__( 'There are', 'site-counts' ),
+						absint( $post_count ),
+						esc_html( $post_type_object->labels->name )
+					);
+					?>
 				</li>
 			<?php endforeach; ?>
 			</ul>
@@ -105,7 +104,6 @@ class Block {
 				);
 			?>
 			</p>
-
 			<?php
 			$current_post = get_the_ID();
 			$query        = new WP_Query(
@@ -126,23 +124,17 @@ class Block {
 					'category_name' => 'baz',
 				]
 			);
-
-			if ( $query->found_posts ) :
-				?>
+			?>
+			<?php if ( $query->found_posts ) : ?>
 				<h2><?php esc_html_e( 'Any 5 posts with the tag of foo and the category of baz', 'site-counts' ); ?></h2>
 				<ul>
-				<?php
-
-				foreach ( array_slice( $query->posts, 0, 5 ) as $post ) :
-					?>
-					<?php if ( $post->ID !== $current_post ) : ?>
-						<li><?php echo esc_html( $post->post_title ); ?></li>
-								<?php
-					endif;
-				endforeach;
-			endif;
-			?>
-			</ul>
+					<?php foreach ( array_slice( $query->posts, 0, 5 ) as $post ) : ?>
+						<?php if ( $post->ID !== $current_post ) : ?>
+							<li><?php echo esc_html( $post->post_title ); ?></li>
+						<?php endif; ?>
+					<?php endforeach; ?>
+				</ul>
+			<?php endif; ?>
 		</div>
 		<?php
 

--- a/php/Block.php
+++ b/php/Block.php
@@ -78,7 +78,7 @@ class Block {
 					get_posts(
 						[
 							'post_type'      => $post_type_slug,
-							'posts_per_page' => -1,
+							'posts_per_page' => -1, // Can we maybe limit this for performance?
 						]
 					)
 				);

--- a/php/Block.php
+++ b/php/Block.php
@@ -101,7 +101,7 @@ class Block {
 				echo sprintf(
 					'%1$s %2$d.',
 					esc_html__( 'The current post ID is', 'site-counts' ),
-					absint( $post->ID )
+					absint( get_the_ID() )
 				);
 			?>
 			</p>

--- a/php/Block.php
+++ b/php/Block.php
@@ -39,7 +39,7 @@ class Block {
 	 * @return void
 	 */
 	public function init() {
-		add_action( 'init', [ $this, 'register_block' ] );
+		add_action( 'init', array( $this, 'register_block' ) );
 	}
 
 	/**
@@ -48,9 +48,9 @@ class Block {
 	public function register_block() {
 		register_block_type_from_metadata(
 			$this->plugin->dir(),
-			[
-				'render_callback' => [ $this, 'render_callback' ],
-			]
+			array(
+				'render_callback' => array( $this, 'render_callback' ),
+			)
 		);
 	}
 
@@ -63,62 +63,67 @@ class Block {
 	 * @return string The markup of the block.
 	 */
 	public function render_callback( $attributes, $content, $block ) {
-		$post_types = get_post_types(  [ 'public' => true ] );
+		$post_types = get_post_types( array( 'public' => true ) );
 		$class_name = $attributes['className'];
 		ob_start();
 
 		?>
-        <div class="<?php echo $class_name; ?>">
+		<div class="<?php echo $class_name; ?>">
 			<h2>Post Counts</h2>
 			<ul>
 			<?php
 			foreach ( $post_types as $post_type_slug ) :
-                $post_type_object = get_post_type_object( $post_type_slug  );
-                $post_count = count(
-                    get_posts(
-						[
-							'post_type' => $post_type_slug,
+				$post_type_object = get_post_type_object( $post_type_slug );
+				$post_count       = count(
+					get_posts(
+						array(
+							'post_type'      => $post_type_slug,
 							'posts_per_page' => -1,
-						]
+						)
 					)
-                );
+				);
 
 				?>
-				<li><?php echo 'There are ' . $post_count . ' ' .
-					  $post_type_object->labels->name . '.'; ?></li>
-			<?php endforeach;	?>
+				<li>
+					<?php echo 'There are ' . $post_count . ' ' . $post_type_object->labels->name . '.'; ?>
+				</li>
+			<?php endforeach; ?>
 			</ul><p><?php echo 'The current post ID is ' . $_GET['post_id'] . '.'; ?></p>
 
 			<?php
-			$query = new WP_Query(  array(
-				'post_type' => ['post', 'page'],
-				'post_status' => 'any',
-				'date_query' => array(
-					array(
-						'hour'      => 9,
-						'compare'   => '>=',
+			$query = new WP_Query(
+				array(
+					'post_type'     => array( 'post', 'page' ),
+					'post_status'   => 'any',
+					'date_query'    => array(
+						array(
+							'hour'    => 9,
+							'compare' => '>=',
+						),
+						array(
+							'hour'    => 17,
+							'compare' => '<=',
+						),
 					),
-					array(
-						'hour' => 17,
-						'compare'=> '<=',
-					),
-				),
-                'tag'  => 'foo',
-                'category_name'  => 'baz',
-				  'post__not_in' => [ get_the_ID() ],
-			));
+					'tag'           => 'foo',
+					'category_name' => 'baz',
+					'post__not_in'  => array( get_the_ID() ),
+				)
+			);
 
 			if ( $query->found_posts ) :
 				?>
-				 <h2>5 posts with the tag of foo and the category of baz</h2>
-                <ul>
-                <?php
+				<h2>5 posts with the tag of foo and the category of baz</h2>
+				<ul>
+				<?php
 
-                 foreach ( array_slice( $query->posts, 0, 5 ) as $post ) :
-                    ?><li><?php echo $post->post_title ?></li><?php
+				foreach ( array_slice( $query->posts, 0, 5 ) as $post ) :
+					?>
+					<li><?php echo $post->post_title; ?></li>
+								<?php
 				endforeach;
 			endif;
-		 	?>
+			?>
 			</ul>
 		</div>
 		<?php

--- a/php/Block.php
+++ b/php/Block.php
@@ -68,8 +68,8 @@ class Block {
 		ob_start();
 
 		?>
-		<div class="<?php echo $class_name; ?>">
-			<h2>Post Counts</h2>
+		<div class="<?php echo esc_attr( $class_name ); ?>">
+			<h2><?php esc_html_e( 'Post Counts', 'site-counts' ); ?></h2>
 			<ul>
 			<?php
 			foreach ( $post_types as $post_type_slug ) :
@@ -85,10 +85,26 @@ class Block {
 
 				?>
 				<li>
-					<?php echo 'There are ' . $post_count . ' ' . $post_type_object->labels->name . '.'; ?>
+				<?php
+				echo sprintf(
+					'%1$s %2$d %3$s',
+					esc_html__( 'There are', 'site-counts' ),
+					absint( $post_count ),
+					esc_html( $post_type_object->labels->name )
+				);
+				?>
 				</li>
 			<?php endforeach; ?>
-			</ul><p><?php echo 'The current post ID is ' . $_GET['post_id'] . '.'; ?></p>
+			</ul>
+			<p>
+			<?php
+				echo sprintf(
+					'%1$s %2$d.',
+					esc_html__( 'The current post ID is', 'site-counts' ),
+					absint( $post->ID )
+				);
+			?>
+			</p>
 
 			<?php
 			$query = new WP_Query(
@@ -113,13 +129,13 @@ class Block {
 
 			if ( $query->found_posts ) :
 				?>
-				<h2>5 posts with the tag of foo and the category of baz</h2>
+				<h2><?php esc_html_e( 'Any 5 posts with the tag of foo and the category of baz', 'site-counts' ); ?></h2>
 				<ul>
 				<?php
 
 				foreach ( array_slice( $query->posts, 0, 5 ) as $post ) :
 					?>
-					<li><?php echo $post->post_title; ?></li>
+					<li><?php echo esc_html( $post->post_title ); ?></li>
 								<?php
 				endforeach;
 			endif;


### PR DESCRIPTION
This PR is part of the hiring process for XWP. The goal was to make improvements to the[`render_callback()`](https://github.com/andrewremery/coding-challenge/blob/bca7be61dd5cfec1067f05b41fa458af6de5a9ea/php/Block.php#L58-L128).

### The following improvements have been made:

- Switched arrays to use short syntax
- Use  `get_the_id` where possible 
- Remove `post__not_in` from the query for performance. Instead favoring a simple `if` statement to check if the loop is on the current post
- Added escaping, sanitizing and localization where possible
- Formatted to fit code standards and make the function more readable  